### PR TITLE
Changed estimation of available free memory.

### DIFF
--- a/src/main/java/com/google/code/externalsorting/ExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/ExternalSort.java
@@ -77,9 +77,15 @@ public class ExternalSort {
          * 
          * @return available memory
          */
-        public static long estimateAvailableMemory() {
-                System.gc();
-                return Runtime.getRuntime().freeMemory();
+        public static long estimateAvailableMemory() 
+        {        	
+        	System.gc();
+
+        	Runtime r = Runtime.getRuntime();
+        	long allocatedMemory =  r.totalMemory() - r.freeMemory();
+			long presFreeMemory = r.maxMemory() - allocatedMemory;
+			
+        	return presFreeMemory;
         }
 
         /**


### PR DESCRIPTION
Hey, I found that the estimation of available memory uses the current heap space, instead of the maximum heapspace (ie. I got lots of little batch files even though I had gigabytes of heap space). This worked for me.

See http://stackoverflow.com/questions/12807797/java-get-available-memory