### PR TITLE
Fixed integer overflow when the number of sorted lines are greater than Integer.MAX_VALUE.

### DIFF
--- a/src/main/java/com/google/code/externalsorting/ExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/ExternalSort.java
@@ -210,7 +210,7 @@ public class ExternalSort {
          * @throws IOException generic IO exception
          *
          */
-        public static int mergeSortedFiles(BufferedWriter fbw,
+        public static long mergeSortedFiles(BufferedWriter fbw,
                 final Comparator<String> cmp, boolean distinct,
                 List<BinaryFileBuffer> buffers) throws IOException {
                 PriorityQueue<BinaryFileBuffer> pq = new PriorityQueue<>(
@@ -226,7 +226,7 @@ public class ExternalSort {
                                 pq.add(bfb);
                         }
                 }
-                int rowcounter = 0;
+                long rowcounter = 0;
                 try {
                         if (!distinct) {
                             while (pq.size() > 0) {
@@ -290,7 +290,7 @@ public class ExternalSort {
          * @return The number of lines sorted.
          * @throws IOException generic IO exception
          */
-        public static int mergeSortedFiles(List<File> files, File outputfile)
+        public static long mergeSortedFiles(List<File> files, File outputfile)
                 throws IOException {
                 return mergeSortedFiles(files, outputfile, defaultcomparator,
                         Charset.defaultCharset());
@@ -306,7 +306,7 @@ public class ExternalSort {
          * @return The number of lines sorted.
          * @throws IOException generic IO exception
          */
-        public static int mergeSortedFiles(List<File> files, File outputfile,
+        public static long mergeSortedFiles(List<File> files, File outputfile,
                 final Comparator<String> cmp) throws IOException {
                 return mergeSortedFiles(files, outputfile, cmp,
                         Charset.defaultCharset());
@@ -324,7 +324,7 @@ public class ExternalSort {
          * @return The number of lines sorted.
          * @throws IOException generic IO exception
          */
-        public static int mergeSortedFiles(List<File> files, File outputfile,
+        public static long mergeSortedFiles(List<File> files, File outputfile,
                 final Comparator<String> cmp, boolean distinct)
                 throws IOException {
                 return mergeSortedFiles(files, outputfile, cmp,
@@ -343,7 +343,7 @@ public class ExternalSort {
          * @return The number of lines sorted.
          * @throws IOException generic IO exception
          */
-        public static int mergeSortedFiles(List<File> files, File outputfile,
+        public static long mergeSortedFiles(List<File> files, File outputfile,
                 final Comparator<String> cmp, Charset cs) throws IOException {
                 return mergeSortedFiles(files, outputfile, cmp, cs, false);
         }
@@ -363,7 +363,7 @@ public class ExternalSort {
          * @throws IOException generic IO exception
          * @since v0.1.2
          */
-        public static int mergeSortedFiles(List<File> files, File outputfile,
+        public static long mergeSortedFiles(List<File> files, File outputfile,
                 final Comparator<String> cmp, Charset cs, boolean distinct)
                 throws IOException {
                 return mergeSortedFiles(files, outputfile, cmp, cs, distinct,
@@ -389,7 +389,7 @@ public class ExternalSort {
          * @throws IOException generic IO exception
          * @since v0.1.4
          */
-        public static int mergeSortedFiles(List<File> files, File outputfile,
+        public static long mergeSortedFiles(List<File> files, File outputfile,
                 final Comparator<String> cmp, Charset cs, boolean distinct,
                 boolean append, boolean usegzip) throws IOException {
                 ArrayList<BinaryFileBuffer> bfbs = new ArrayList<>();
@@ -412,7 +412,7 @@ public class ExternalSort {
                 }
                 BufferedWriter fbw = new BufferedWriter(new OutputStreamWriter(
                         new FileOutputStream(outputfile, append), cs));
-                int rowcounter = mergeSortedFiles(fbw, cmp, distinct, bfbs);
+                long rowcounter = mergeSortedFiles(fbw, cmp, distinct, bfbs);
                 for (File f : files) {
                         f.delete();
                 }

--- a/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.github.jamm.*;
 
@@ -419,6 +420,7 @@ public class ExternalSortTest {
      *
      * @throws IOException
      */
+    @Ignore("This test takes too long to execute")
     @Test
     public void sortVeryLargeFile() throws IOException {
         final Path veryLargeFile = getTestFile();

--- a/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
@@ -13,11 +13,18 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -405,6 +412,48 @@ public class ExternalSortTest {
         try (FileOutputStream out = new FileOutputStream(f)) {
             out.write(s.getBytes());
         }
+    }
+
+    /**
+     * Sort a text file with lines greater than {@link Integer#MAX_VALUE}.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void sortVeryLargeFile() throws IOException {
+        final Path veryLargeFile = getTestFile();
+        final Path outputFile = Files.createTempFile("Merged-File", ".tmp");
+        final long sortedLines = ExternalSort.mergeSortedFiles(ExternalSort.sortInBatch(veryLargeFile.toFile()), outputFile.toFile());
+        final long expectedLines = 2148L * 1000000L;
+        assertEquals(expectedLines, sortedLines);
+    }
+
+    /**
+     * Generate a test file with 2148 million lines.
+     *
+     * @throws IOException
+     */
+    private Path getTestFile() throws IOException {
+        System.out.println("Temp File Creation: Started");
+        final Path path = Files.createTempFile("IntegrationTestFile", ".txt");
+        final List<String> idList = new ArrayList<>();
+        final int saneLimit = 1000000;
+        IntStream.range(0, saneLimit)
+                .forEach(i -> idList.add("A"));
+        final String content = idList.stream().collect(Collectors.joining("\n"));
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
+        final String newLine = "\n";
+        IntStream.range(1, 2148)
+                .forEach(i -> {
+                    try {
+                        Files.write(path, newLine.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                        Files.write(path, content.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e.getMessage());
+                    }
+                });
+        System.out.println("Temp File Creation: Finished");
+        return path;
     }
 
 }


### PR DESCRIPTION
Currently the rowcounter is `int` based, this overflows when the number of lines is greater than Integer.MAX_VALUE (2^32 - 1).

A simple change is implemented, `int` has been switched in favour of `long`. 
Overflow can still occur, but only if sorted lines exceed Long.MAX_VALUE (2^63 - 1), which is extremely unlikely.

Added a unit test for sorting a very large file (2148 million lines).
This test takes pretty long and maybe should be disabled but kept for future reference.