### PR TITLE
Fixed test assert 'expected' oder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ How to build
 - get the java jdk
 - Install Maven 2
 - mvn install - builds jar (requires signing)
+- or mvn package - builds jar (does not require signing)
 - mvn test - runs tests
 
 

--- a/src/main/java/com/google/code/externalsorting/csv/CsvExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/csv/CsvExternalSort.java
@@ -71,7 +71,7 @@ public class CsvExternalSort {
 	}
 
 	public static int mergeSortedFiles(BufferedWriter fbw, final CsvSortOptions sortOptions,
-			ArrayList<CSVRecordBuffer> bfbs) throws IOException, ClassNotFoundException {
+			List<CSVRecordBuffer> bfbs) throws IOException, ClassNotFoundException {
 		PriorityQueue<CSVRecordBuffer> pq = new PriorityQueue<CSVRecordBuffer>(11, new Comparator<CSVRecordBuffer>() {
 			@Override
 			public int compare(CSVRecordBuffer i, CSVRecordBuffer j) {
@@ -113,7 +113,7 @@ public class CsvExternalSort {
 
 	public static int mergeSortedFiles(List<File> files, File outputfile, final CsvSortOptions sortOptions, boolean append) throws IOException, ClassNotFoundException {
 
-		ArrayList<CSVRecordBuffer> bfbs = new ArrayList<CSVRecordBuffer>();
+		List<CSVRecordBuffer> bfbs = new ArrayList<CSVRecordBuffer>();
 		for (File f : files) {
 			InputStream in = new FileInputStream(f);
 			BufferedReader fbr = new BufferedReader(new InputStreamReader(in, sortOptions.getCharset()));

--- a/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
@@ -6,32 +6,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Random;
-import java.util.Scanner;
-import java.util.TreeSet;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -478,7 +460,7 @@ public class ExternalSortTest {
         Random rand = new Random();
         final Path path = Files.createTempFile("TestCsvWithLongIds", ".csv");
         final Path pathSorted = Files.createTempFile("TestCsvWithLongIdsSorted", ".csv");
-        TreeSet<Long> sortedIds = new TreeSet<>();
+        Set<Long> sortedIds = new TreeSet<>();
         try (FileWriter fw = new FileWriter(path.toFile());
              BufferedWriter bw = new BufferedWriter(fw)) {
             for (int i = 0; i < 1000; ++i) {
@@ -512,7 +494,7 @@ public class ExternalSortTest {
                 "Val2,Data2,Data4,Data5\r\n" +
                 "Val1,Data2,Data3,Data5\r\n" +
                 "Val2,Data2,Data6,Data7\r\n";
-        ByteArrayInputStream bis = new ByteArrayInputStream(unsortedContent.getBytes(StandardCharsets.UTF_8));
+        InputStream bis = new ByteArrayInputStream(unsortedContent.getBytes(StandardCharsets.UTF_8));
         File tmpDirectory = Files.createTempDirectory("sort").toFile();
         tmpDirectory.deleteOnExit();
 

--- a/src/test/java/com/google/code/externalsorting/csv/CsvExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/csv/CsvExternalSortTest.java
@@ -54,16 +54,16 @@ public class CsvExternalSortTest {
 
 		List<File> sortInBatch = CsvExternalSort.sortInBatch(file, null, sortOptions);
 		
-		assertEquals(sortInBatch.size(), 1);
+		assertEquals(1, sortInBatch.size());
 		
 		int mergeSortedFiles = CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, true);
 		
-		assertEquals(mergeSortedFiles, 4);
+		assertEquals(4, mergeSortedFiles);
 		
 		BufferedReader reader = new BufferedReader(new FileReader(outputfile));
 		String readLine = reader.readLine();
 
-		assertEquals(readLine, "6,this wont work in other systems,3");
+		assertEquals("6,this wont work in other systems,3", readLine);
 		reader.close();
 	}
 
@@ -93,17 +93,17 @@ public class CsvExternalSortTest {
 
 		List<File> sortInBatch = CsvExternalSort.sortInBatch(file, null, sortOptions);
 
-		assertEquals(sortInBatch.size(), 1);
+		assertEquals(1, sortInBatch.size());
 
 		int mergeSortedFiles = CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, true);
 
-		assertEquals(mergeSortedFiles, 5);
+		assertEquals(5, mergeSortedFiles);
 
 		List<String> lines = Files.readAllLines(Paths.get(outputfile.getPath()), StandardCharsets.UTF_8);
 
-		assertEquals(lines.get(0), "2,זה רק טקסט אחי לקריאה קשה,8");
-		assertEquals(lines.get(1), "5,هذا هو النص إخوانه فقط من الصعب القراءة,3");
-		assertEquals(lines.get(2), "6,это не будет работать в других системах,3");
+		assertEquals("2,זה רק טקסט אחי לקריאה קשה,8", lines.get(0));
+		assertEquals("5,هذا هو النص إخوانه فقط من الصعب القراءة,3", lines.get(1));
+		assertEquals("6,это не будет работать в других системах,3", lines.get(2));
 	}
 
 
@@ -135,11 +135,11 @@ public class CsvExternalSortTest {
 
 			List<File> sortInBatch = CsvExternalSort.sortInBatch(file,  null, sortOptions);
 
-			assertEquals(sortInBatch.size(), 1);
+			assertEquals(1, sortInBatch.size());
 
 			int mergeSortedFiles = CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, false);
 
-			assertEquals(mergeSortedFiles, 4);
+			assertEquals(4, mergeSortedFiles);
 
 			List<String> lines = Files.readAllLines(outputfile.toPath());
 
@@ -169,16 +169,16 @@ public class CsvExternalSortTest {
 
 		List<File> sortInBatch = CsvExternalSort.sortInBatch(file, null, sortOptions);
 
-		assertEquals(sortInBatch.size(), 1);
+		assertEquals(1, sortInBatch.size());
 
 		int mergeSortedFiles = CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, true);
 
-		assertEquals(mergeSortedFiles, 5);
+		assertEquals(5, mergeSortedFiles);
 
 		List<String> lines = Files.readAllLines(outputfile.toPath(), sortOptions.getCharset());
 
-		assertEquals(lines.get(0), "personId,text,ishired");
-		assertEquals(lines.get(1), "6,this wont work in other systems,3");
+		assertEquals("personId,text,ishired", lines.get(0));
+		assertEquals("6,this wont work in other systems,3", lines.get(1));
 	}
 
 	@After


### PR DESCRIPTION
Minor fix of 'expected' test assert order

Further, it seems that the `CsvSortOptions` and up-to-date `CsvExternalSort` as described in the readme are not in the latest `0.4.0` release version.