### PR TITLE
Update commons-csv to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 			<dependency>
 			    <groupId>org.apache.commons</groupId>
 			    <artifactId>commons-csv</artifactId>
-			    <version>1.4</version>
+			    <version>1.9.0</version>
 			</dependency>
         
         </dependencies>
@@ -71,7 +71,6 @@
         <dependency>
         	<groupId>org.apache.commons</groupId>
         	<artifactId>commons-csv</artifactId>
-        	<version>1.4</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
commons-csv:1.4 is quite old, let's update it to 1.9.0.
So when commons-csv:1.9.0 is used in the project and running in runtime, externalsortinginjava compiled against 1.9 as well.