### PR TITLE
Cast strings to integers so as to sort as expected

### DIFF
--- a/src/main/java/com/google/code/externalsorting/ExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/ExternalSort.java
@@ -910,11 +910,17 @@ public class ExternalSort {
 
         /**
          * default comparator between strings.
+         * While sorting integers without casting inputs to integers
+         * gives incorrect sort for ex., 1000000000 is less than 100000001
          */
         public static Comparator<String> defaultcomparator = new Comparator<String>() {
                 @Override
                 public int compare(String r1, String r2) {
-                        return r1.compareTo(r2);
+                        if(r1.matches("\\d+") && r2.matches("\\d+")) {
+                                return Integer.compare(Integer.parseInt(r1), Integer.parseInt(r2));
+                        } else {
+                                return r1.compareTo(r2);
+                        }                        
                 }
         };
 

--- a/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
@@ -151,6 +151,15 @@ public class ExternalSortTest {
 
     }
 
+    /**
+     * Compare integers only to verify they are sorted as epected
+     */
+    @Test
+    public void compareIntegers() {        
+        assertEquals(ExternalSort.defaultcomparator.compare("1000000000", "100000001"), 1);
+        assertEquals(ExternalSort.defaultcomparator.compare("100000001", "1000000000"), -1);
+    }
+
     @Test
     public void stringSizeEstimator() {
       for(int k = 0; k < 10; ++k) {


### PR DESCRIPTION
Hi,

Thanks for this code. I could sort billions of lines. However, I identified a tiny issue while sorting integers of variable length like below..

1000000000 is smaller than 100000001
100000010 is smaller than 10000001
100000020 is smaller than 10000002
and so on.,

This is because of `r1.compareTo(r2)` method call in `defaultcomparator`. 
When they are compared as strings, 1000000000 is indeed smaller than 100000001. But it's incorrect when it is an integer. 

This PR checks whether input contain all numerical digits & sort them as integers. 

Looking forward to hear from you. 