### PR TITLE
#46 Counts row written correctly when distinct enabled, both for csv and regular

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import com.google.code.externalsorting.ExternalSort;
 //... inputfile: input file name
 //... outputfile: output file name
 // next command sorts the lines from inputfile to outputfile
-ExternalSort.mergeSortedFiles(ExternalSort.sortInBatch(new File(inputfile)), new File(outputfile));
+int numLinesWritten = ExternalSort.mergeSortedFiles(ExternalSort.sortInBatch(new File(inputfile)), new File(outputfile));
 // you can also provide a custom string comparator, see API
 ```
 
@@ -56,7 +56,7 @@ ArrayList<CSVRecord> header = new ArrayList<CSVRecord>();
 // next two lines sort the lines from inputfile to outputfile
 List<File> sortInBatch = CsvExternalSort.sortInBatch(file, null, sortOptions, header);
 // at this point you can access header if you'd like.
-CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, true, header);
+int numWrittenLines = CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, true, header);
 
 ```
 

--- a/src/main/java/com/google/code/externalsorting/ExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/ExternalSort.java
@@ -226,7 +226,7 @@ public class ExternalSort {
                                 pq.add(bfb);
                         }
                 }
-                long rowcounter = 0;
+                long numLinesWritten = 0;
                 try {
                         if (!distinct) {
                             while (pq.size() > 0) {
@@ -234,7 +234,7 @@ public class ExternalSort {
                                     String r = bfb.pop();
                                     fbw.write(r);
                                     fbw.newLine();
-                                    ++rowcounter;
+                                    ++numLinesWritten;
                                     if (bfb.empty()) {
                                             bfb.close();
                                     } else {
@@ -248,7 +248,7 @@ public class ExternalSort {
                            lastLine = bfb.pop();
                            fbw.write(lastLine);
                            fbw.newLine();
-                           ++rowcounter;
+                           ++numLinesWritten;
                            if (bfb.empty()) {
                              bfb.close();
                            } else {
@@ -263,8 +263,8 @@ public class ExternalSort {
                             fbw.write(r);
                             fbw.newLine();
                             lastLine = r;
+                            ++numLinesWritten;
                           }
-                          ++rowcounter;
                           if (bfb.empty()) {
                             bfb.close();
                           } else {
@@ -278,7 +278,7 @@ public class ExternalSort {
                                 bfb.close();
                         }
                 }
-                return rowcounter;
+                return numLinesWritten;
 
         }
 
@@ -460,11 +460,11 @@ public class ExternalSort {
                         BinaryFileBuffer bfb = new BinaryFileBuffer(br);
                         bfbs.add(bfb);
                 }
-                long rowcounter = mergeSortedFiles(fbw, cmp, distinct, bfbs);
+                long numLinesWritten = mergeSortedFiles(fbw, cmp, distinct, bfbs);
                 for (File f : files) {
                         f.delete();
                 }
-                return rowcounter;
+                return numLinesWritten;
         }
 
         /**

--- a/src/main/java/com/google/code/externalsorting/csv/CsvExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/csv/CsvExternalSort.java
@@ -81,7 +81,7 @@ public class CsvExternalSort {
 		for (CSVRecordBuffer bfb : bfbs)
 			if (!bfb.empty())
 				pq.add(bfb);
-		int rowcounter = 0;
+		int numWrittenLines = 0;
 		CSVPrinter printer = new CSVPrinter(fbw, sortOptions.getFormat());
 		if(! sortOptions.isSkipHeader()) {
 			for(CSVRecord r: header) {
@@ -98,8 +98,8 @@ public class CsvExternalSort {
 				} else {
 					printer.printRecord(r);
 					lastLine = r;
+					++numWrittenLines;
 				}
-				++rowcounter;
 				if (bfb.empty()) {
 					bfb.close();
 				} else {
@@ -113,7 +113,7 @@ public class CsvExternalSort {
 				bfb.close();
 		}
 
-		return rowcounter;
+		return numWrittenLines;
 	}
 
 	public static int mergeSortedFiles(List<File> files, File outputfile, final CsvSortOptions sortOptions,
@@ -131,14 +131,14 @@ public class CsvExternalSort {
 		BufferedWriter fbw = new BufferedWriter(
 				new OutputStreamWriter(new FileOutputStream(outputfile, append), sortOptions.getCharset()));
 
-		int rowcounter = mergeSortedFiles(fbw, sortOptions, bfbs, header);
+		int numWrittenLines = mergeSortedFiles(fbw, sortOptions, bfbs, header);
 		for (File f : files) {
 			if (!f.delete()) {
 				LOG.log(Level.WARNING, String.format("The file %s was not deleted", f.getName()));
 			}
 		}
 
-		return rowcounter;
+		return numWrittenLines;
 	}
 
 	public static List<File> sortInBatch(long size_in_byte, final BufferedReader fbr, final File tmpdirectory,

--- a/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/ExternalSortTest.java
@@ -1,5 +1,6 @@
 package com.google.code.externalsorting;
 
+import static com.google.code.externalsorting.ExternalSort.defaultcomparator;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -206,8 +207,8 @@ public class ExternalSortTest {
         };
         File out = File.createTempFile("test_results", ".tmp", null);
         out.deleteOnExit();
-        ExternalSort.mergeSortedFiles(this.fileList, out, cmp,
-                                      Charset.defaultCharset(), true);
+        long numLinesWritten = ExternalSort.mergeSortedFiles(this.fileList, out, cmp,
+                Charset.defaultCharset(), true);
 
         List<String> result = new ArrayList<>();
         try (BufferedReader bf = new BufferedReader(new FileReader(out))) {
@@ -215,6 +216,8 @@ public class ExternalSortTest {
                 result.add(line);
             }
         }
+
+        assertEquals(11, numLinesWritten);
         assertArrayEquals(Arrays.toString(result.toArray()), EXPECTED_MERGE_DISTINCT_RESULTS,
                           result.toArray());
     }
@@ -399,9 +402,22 @@ public class ExternalSortTest {
     public void sortVeryLargeFile() throws IOException {
         final Path veryLargeFile = getTestFile();
         final Path outputFile = Files.createTempFile("Merged-File", ".tmp");
-        final long sortedLines = ExternalSort.mergeSortedFiles(ExternalSort.sortInBatch(veryLargeFile.toFile()), outputFile.toFile());
+        final long numLinesWritten = ExternalSort.mergeSortedFiles(ExternalSort.sortInBatch(veryLargeFile.toFile()), outputFile.toFile());
         final long expectedLines = 2148L * 1000000L;
-        assertEquals(expectedLines, sortedLines);
+        assertEquals(expectedLines, numLinesWritten);
+    }
+
+    @Ignore("This test takes too long to execute")
+    @Test
+    public void sortVeryLargeFileWhenDistinctEnabled() throws IOException {
+        boolean distinctEnabled = true;
+        final Path veryLargeFile = getTestFile();
+        final File outputFile = Files.createTempFile("Merged-File", ".tmp").toFile();
+        List<File> veryLargeSortBatch = ExternalSort.sortInBatch(veryLargeFile.toFile());
+
+        long numLinesWritten = ExternalSort.mergeSortedFiles(veryLargeSortBatch, outputFile, defaultcomparator, distinctEnabled);
+
+        assertEquals(1 /* 😸 */, numLinesWritten);
     }
 
     /**


### PR DESCRIPTION
Addresses [#46]

Returns the number of written records when the `distinct` flag is _enabled_.

The assumption is that the _count_ returned by the `mergeSort()` method is the number of rows in the output file, which has to be opened and traversed by the user of the library otherwise.

- Both `ExternalSort` and `CsvExternalSort` were adjusted to reflect this
- Both big `@Ignored("Takes too long")` tests run
- Test added or updated when appropriate
- Updated `README.md` to show `numLinesWritten` variable