### PR TITLE
Implement stable merging of external files

### DIFF
--- a/src/main/java/com/google/code/externalsorting/csv/CsvExternalSort.java
+++ b/src/main/java/com/google/code/externalsorting/csv/CsvExternalSort.java
@@ -10,14 +10,21 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
@@ -85,15 +92,22 @@ public class CsvExternalSort {
      */
     public static int mergeSortedFiles(BufferedWriter fbw, final CsvSortOptions sortOptions, List<CSVRecordBuffer> bfbs, List<CSVRecord> header)
 	    throws IOException, ClassNotFoundException {
-		PriorityQueue<CSVRecordBuffer> pq = new PriorityQueue<CSVRecordBuffer>(11, new Comparator<CSVRecordBuffer>() {
-			@Override
-			public int compare(CSVRecordBuffer i, CSVRecordBuffer j) {
-				return sortOptions.getComparator().compare(i.peek(), j.peek());
-			}
-		});
-		for (CSVRecordBuffer bfb : bfbs)
-			if (!bfb.empty())
+
+		final Map<Integer, CSVRecordBuffer> indexedBfbs = new LinkedHashMap<>();
+		IntStream.range(0, bfbs.size())
+			.forEach(i -> indexedBfbs.put(i, bfbs.get(i)));
+
+		PriorityQueue<Map.Entry<Integer, CSVRecordBuffer>> pq = new PriorityQueue<>(11,
+			Comparator
+				.comparing((Function<Map.Entry<Integer, CSVRecordBuffer>, CSVRecord>) e -> e.getValue().peek(),
+					sortOptions.getComparator())
+				// Use the index of the sort file as final sort criterion, to keep the merge algorithm stable
+				.thenComparing(Map.Entry::getKey));
+
+		for (Map.Entry<Integer, CSVRecordBuffer> bfb : indexedBfbs.entrySet())
+			if (!bfb.getValue().empty())
 				pq.add(bfb);
+
 		int numWrittenLines = 0;
 		CSVPrinter printer = new CSVPrinter(fbw, sortOptions.getFormat());
 		if(! sortOptions.isSkipHeader()) {
@@ -103,9 +117,9 @@ public class CsvExternalSort {
 		}
 		CSVRecord lastLine = null;
 		try {
-			while (pq.size() > 0) {
-				CSVRecordBuffer bfb = pq.poll();
-				CSVRecord r = bfb.pop();
+			while (!pq.isEmpty()) {
+				Map.Entry<Integer, CSVRecordBuffer> bfb = pq.poll();
+				CSVRecord r = bfb.getValue().pop();
 				// Skip duplicate lines
 				if (sortOptions.isDistinct() && checkDuplicateLine(r, lastLine)) {
 				} else {
@@ -113,8 +127,8 @@ public class CsvExternalSort {
 					lastLine = r;
 					++numWrittenLines;
 				}
-				if (bfb.empty()) {
-					bfb.close();
+				if (bfb.getValue().empty()) {
+					bfb.getValue().close();
 				} else {
 					pq.add(bfb); // add it back
 				}
@@ -122,8 +136,8 @@ public class CsvExternalSort {
 		} finally {
 			printer.close();
 			fbw.close();
-			for (CSVRecordBuffer bfb : pq)
-				bfb.close();
+			for (Map.Entry<Integer, CSVRecordBuffer> bfb : pq)
+				bfb.getValue().close();
 		}
 
 		return numWrittenLines;

--- a/src/test/java/com/google/code/externalsorting/csv/CsvExternalSortTest.java
+++ b/src/test/java/com/google/code/externalsorting/csv/CsvExternalSortTest.java
@@ -1,9 +1,7 @@
 package com.google.code.externalsorting.csv;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVRecord;
-import org.junit.After;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -13,14 +11,19 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
 
 
 public class CsvExternalSortTest {
@@ -258,6 +261,46 @@ public class CsvExternalSortTest {
 		assertNotEquals(firstLine, secondLine);
 
 		reader.close();
+	}
+
+	@Test
+	public void testStableSort() throws Exception {
+
+		/* GIEVN */
+		final String path = getClass().getClassLoader().getResource("test-file-3.csv").getPath();
+		File file = new File(path);
+
+		outputfile = new File("test-file-3-sorted.csv");
+
+		// Sort by 'author'
+		Comparator<CSVRecord> comparator = Comparator.comparing(r -> r.get(1));
+
+		CsvSortOptions sortOptions = new CsvSortOptions
+			// Keep the maxMemory small, so we split the every line into its own file
+			.Builder(comparator, CsvExternalSort.DEFAULTMAXTEMPFILES, 15)
+			.charset(StandardCharsets.UTF_8)
+			.distinct(false)
+			.numHeader(1)
+			.skipHeader(true)
+			.format(CSVFormat.DEFAULT)
+			.build();
+		ArrayList<CSVRecord> header = new ArrayList<>();
+
+		/* WHEN */
+		List<File> sortInBatch = CsvExternalSort.sortInBatch(file, null, sortOptions, header);
+		CsvExternalSort.mergeSortedFiles(sortInBatch, outputfile, sortOptions, true, header);
+
+		/* THEN */
+		List<String> lines = Files.readAllLines(Paths.get(outputfile.getPath()), StandardCharsets.UTF_8);
+
+		for(String a : lines) {
+			System.out.println(a);
+		}
+
+		List<Integer> indices = lines.stream()
+			.map(l -> Integer.valueOf(l.split(",")[0]))
+			.collect(Collectors.toList());
+		Assert.assertEquals(Arrays.asList(1, 2, 3, 4, 5), indices);
 	}
 
 	@After

--- a/src/test/resources/test-file-3.csv
+++ b/src/test/resources/test-file-3.csv
@@ -1,0 +1,6 @@
+"id","author"
+"1","Dan Simmons"
+"2","Dan Simmons"
+"3","Dan Simmons"
+"4","Dan Simmons"
+"5","Dan Simmons"


### PR DESCRIPTION
Hi there, I hope it is ok to just create a pull request here. If you have a different process, just let me know.

---

The external sorting for CSV files is currently not stable in regard to 'equal' rows. Please find a reproducer test case `testStableSort` contained in this PR.

The reason for this is how the merging is implemented using a `PriorityQueue`. Essentially the `CSVRecordBuffer`'s are shuffled during the merge process, so the order of the input files is lost during the process.

The solution implemented in this PR keeps track of the index of the the `CSVREcordBuffer`s and uses it as a a last sort criterium (applied after the custom comparator) within the merging process, and thus preserving the order passed in the list of files to merge.

Since the original `sortInBatch` is implemented using `Collections.sort`, it should already be guaranteed that the batches themselves are sorted in a stable manner.

Br, Matthias